### PR TITLE
Allow aria host to be set on a different element

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,9 @@
                 z-index: 1;
             }
             .expander__host[aria-expanded=true] ~ .expander__content,
-            .expander__host[aria-expanded=true] ~ .expander  .expander__content {
+            .expander__host[aria-expanded=true] ~ .expander  .expander__content,
+            .expander__host.expanded ~ .expander__content,
+            .expander__host.expanded ~ .expander  .expander__content {
                 display: block;
             }
             .clipped {
@@ -105,6 +107,25 @@
                         <p>An input: <input type="text" aria-label="Dummy textbox"></p>
                         <p>A checkbox: <input type="checkbox" aria-label="Dummy checkbox"></p>
                     </div>
+                </div>
+            </span>
+
+            <div class="expander expander--click-only-nested flyout">
+                <span class="expander__host"><button class="flyout__host">Click for Flyout - nested button</button></span>
+                <div class="expander__content flyout__content">
+                    <p>Any kind of HTML control can go inside...</p>
+                    <p>A link:
+                        <a id="foo" href="http://www.ebay.com">www.ebay.com</a>
+                    </p>
+                    <p>A button:
+                        <button>Click Me</button>
+                    </p>
+                    <p>An input:
+                        <input type="text" aria-label="Dummy textbox">
+                    </p>
+                    <p>A checkbox:
+                        <input type="checkbox" aria-label="Dummy checkbox">
+                    </p>
                 </div>
             </span>
         </main>

--- a/docs/index.html
+++ b/docs/index.html
@@ -25,8 +25,8 @@
             }
             .expander__host[aria-expanded=true] ~ .expander__content,
             .expander__host[aria-expanded=true] ~ .expander  .expander__content,
-            .expander__host.expanded ~ .expander__content,
-            .expander__host.expanded ~ .expander  .expander__content {
+            .expander-expanded ~ .expander__content,
+            .expander-expanded ~ .expander  .expander__content {
                 display: block;
             }
             .clipped {

--- a/docs/index.js
+++ b/docs/index.js
@@ -4,6 +4,7 @@ function nodeListToArray(nodeList) {
 
 var Expander = require('../index.js');
 var clickExpanderEls = nodeListToArray(document.querySelectorAll('.expander--click-only'));
+var clickNestedExpanderEls = nodeListToArray(document.querySelectorAll('.expander--click-only-nested'));
 var focusExpanderEls = nodeListToArray(document.querySelectorAll('.expander--focus-only'));
 var hoverExpanderEls = nodeListToArray(document.querySelectorAll('.expander--hover-only'));
 var hoverAndFocusExpanderEls = nodeListToArray(document.querySelectorAll('.expander--focus-and-hover'));
@@ -12,6 +13,10 @@ var expanderWidgets = [];
 
 clickExpanderEls.forEach(function(el, i) {
     expanderWidgets.push(new Expander(el, { click: true }));
+});
+
+clickNestedExpanderEls.forEach(function(el, i) {
+    expanderWidgets.push(new Expander(el, { click: true, ariaHostSelector: '.expander__host > .flyout__host' }));
 });
 
 focusExpanderEls.forEach(function(el, i) {

--- a/docs/static/bundle.js
+++ b/docs/static/bundle.js
@@ -854,7 +854,7 @@ module.exports = function () {
             }
 
             if (this.options.ariaHostSelector !== null && this.options.expandedClass === null) {
-                this.options.expandedClass = 'expanded';
+                this.options.expandedClass = 'expander-expanded';
             }
 
             this.click = this.options.click;

--- a/index.js
+++ b/index.js
@@ -17,7 +17,9 @@ var defaultOptions = {
     focus: false,
     focusManagement: null,
     hostSelector: '.expander__host',
-    hover: false
+    hover: false,
+    ariaHostSelector: null,
+    expandedClass: null
 };
 
 function _onKeyDown() {
@@ -32,6 +34,7 @@ module.exports = function () {
 
         this.el = el;
         this.hostEl = el.querySelector(this.options.hostSelector);
+        this.ariaHostEl = el.querySelector(this.options.ariaHostSelector) || this.hostEl;
         this.expandeeEl = el.querySelector(this.options.contentSelector);
 
         // ensure the widget and expandee have an id
@@ -50,10 +53,14 @@ module.exports = function () {
 
         if (this.expandeeEl) {
             // the expander controls the expandee
-            this.hostEl.setAttribute('aria-controls', this.expandeeEl.id);
+            this.ariaHostEl.setAttribute('aria-controls', this.expandeeEl.id);
 
-            if (this.hostEl.getAttribute('aria-expanded') === null) {
-                this.hostEl.setAttribute('aria-expanded', 'false');
+            if (this.ariaHostEl.getAttribute('aria-expanded') === null) {
+                this.ariaHostEl.setAttribute('aria-expanded', 'false');
+            }
+
+            if (this.options.ariaHostSelector !== null && this.options.expandedClass === null) {
+                this.options.expandedClass = 'expanded';
             }
 
             this.click = this.options.click;
@@ -67,13 +74,16 @@ module.exports = function () {
     _createClass(_class, [{
         key: 'isExpanded',
         value: function isExpanded() {
-            return this.hostEl.getAttribute('aria-expanded') === 'true';
+            return this.ariaHostEl.getAttribute('aria-expanded') === 'true';
         }
     }, {
         key: 'collapse',
         value: function collapse() {
             if (this.isExpanded() === true) {
-                this.hostEl.setAttribute('aria-expanded', 'false');
+                if (this.options.expandedClass) {
+                    this.hostEl.classList.remove(this.options.expandedClass);
+                }
+                this.ariaHostEl.setAttribute('aria-expanded', 'false');
                 this.el.dispatchEvent(new CustomEvent('expander-collapse', { bubbles: true, detail: this.expandeeEl }));
             }
         }
@@ -81,7 +91,10 @@ module.exports = function () {
         key: 'expand',
         value: function expand(isKeyboard) {
             if (this.isExpanded() === false) {
-                this.hostEl.setAttribute('aria-expanded', 'true');
+                if (this.options.expandedClass) {
+                    this.hostEl.classList.add(this.options.expandedClass);
+                }
+                this.ariaHostEl.setAttribute('aria-expanded', 'true');
                 if (isKeyboard === true) {
                     var focusManagement = this.options.focusManagement;
 
@@ -121,12 +134,12 @@ module.exports = function () {
                 this.el.addEventListener('mouseleave', this._mouseLeaveListener);
 
                 if (this.options.focus !== true) {
-                    this.hostEl.addEventListener('focus', this._focusExitListener);
+                    this.ariaHostEl.addEventListener('focus', this._focusExitListener);
                 }
             } else {
                 this.el.removeEventListener('mouseleave', this._mouseLeaveListener);
                 this.el.removeEventListener('focusExit', this._focusExitListener);
-                this.hostEl.removeEventListener('focus', this._focusExitListener);
+                this.ariaHostEl.removeEventListener('focus', this._focusExitListener);
             }
         }
     }, {
@@ -144,9 +157,9 @@ module.exports = function () {
         key: 'focus',
         set: function set(bool) {
             if (bool === true) {
-                this.hostEl.addEventListener('focus', this._hostFocusListener);
+                this.ariaHostEl.addEventListener('focus', this._hostFocusListener);
             } else {
-                this.hostEl.removeEventListener('focus', this._hostFocusListener);
+                this.ariaHostEl.removeEventListener('focus', this._hostFocusListener);
             }
         }
     }, {

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ module.exports = function () {
             }
 
             if (this.options.ariaHostSelector !== null && this.options.expandedClass === null) {
-                this.options.expandedClass = 'expanded';
+                this.options.expandedClass = 'expander-expanded';
             }
 
             this.click = this.options.click;

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ module.exports = class {
             }
 
             if (this.options.ariaHostSelector !== null && this.options.expandedClass === null) {
-                this.options.expandedClass = 'expanded';
+                this.options.expandedClass = 'expander-expanded';
             }
 
             this.click = this.options.click;

--- a/test/data.js
+++ b/test/data.js
@@ -1,9 +1,14 @@
 'use strict';
 
 var htmlTemplate1 = '<span class="expander">'
-    + '<button class="expander__host"><button>'
+    + '<button class="expander__host"></button>'
     + '<div class="expander__content"></div>'
 + '</span>';
+
+var htmlTemplate2 = '<span class="expander">'
+    + '<span class="expander__host"><button></button></span>'
+    + '<div class="expander__content"></div>'
+    + '</span>';
 
 module.exports = [
     {

--- a/test/static/bundle-module.js
+++ b/test/static/bundle-module.js
@@ -217,7 +217,9 @@ var defaultOptions = {
     focus: false,
     focusManagement: null,
     hostSelector: '.expander__host',
-    hover: false
+    hover: false,
+    ariaHostSelector: null,
+    expandedClass: null
 };
 
 function _onKeyDown() {
@@ -232,6 +234,7 @@ module.exports = function () {
 
         this.el = el;
         this.hostEl = el.querySelector(this.options.hostSelector);
+        this.ariaHostEl = el.querySelector(this.options.ariaHostSelector) || this.hostEl;
         this.expandeeEl = el.querySelector(this.options.contentSelector);
 
         // ensure the widget and expandee have an id
@@ -250,10 +253,14 @@ module.exports = function () {
 
         if (this.expandeeEl) {
             // the expander controls the expandee
-            this.hostEl.setAttribute('aria-controls', this.expandeeEl.id);
+            this.ariaHostEl.setAttribute('aria-controls', this.expandeeEl.id);
 
-            if (this.hostEl.getAttribute('aria-expanded') === null) {
-                this.hostEl.setAttribute('aria-expanded', 'false');
+            if (this.ariaHostEl.getAttribute('aria-expanded') === null) {
+                this.ariaHostEl.setAttribute('aria-expanded', 'false');
+            }
+
+            if (this.options.ariaHostSelector !== null && this.options.expandedClass === null) {
+                this.options.expandedClass = 'expanded';
             }
 
             this.click = this.options.click;
@@ -267,13 +274,16 @@ module.exports = function () {
     _createClass(_class, [{
         key: 'isExpanded',
         value: function isExpanded() {
-            return this.hostEl.getAttribute('aria-expanded') === 'true';
+            return this.ariaHostEl.getAttribute('aria-expanded') === 'true';
         }
     }, {
         key: 'collapse',
         value: function collapse() {
             if (this.isExpanded() === true) {
-                this.hostEl.setAttribute('aria-expanded', 'false');
+                if (this.options.expandedClass) {
+                    this.hostEl.classList.remove(this.options.expandedClass);
+                }
+                this.ariaHostEl.setAttribute('aria-expanded', 'false');
                 this.el.dispatchEvent(new CustomEvent('expander-collapse', { bubbles: true, detail: this.expandeeEl }));
             }
         }
@@ -281,7 +291,10 @@ module.exports = function () {
         key: 'expand',
         value: function expand(isKeyboard) {
             if (this.isExpanded() === false) {
-                this.hostEl.setAttribute('aria-expanded', 'true');
+                if (this.options.expandedClass) {
+                    this.hostEl.classList.add(this.options.expandedClass);
+                }
+                this.ariaHostEl.setAttribute('aria-expanded', 'true');
                 if (isKeyboard === true) {
                     var focusManagement = this.options.focusManagement;
 
@@ -321,12 +334,12 @@ module.exports = function () {
                 this.el.addEventListener('mouseleave', this._mouseLeaveListener);
 
                 if (this.options.focus !== true) {
-                    this.hostEl.addEventListener('focus', this._focusExitListener);
+                    this.ariaHostEl.addEventListener('focus', this._focusExitListener);
                 }
             } else {
                 this.el.removeEventListener('mouseleave', this._mouseLeaveListener);
                 this.el.removeEventListener('focusExit', this._focusExitListener);
-                this.hostEl.removeEventListener('focus', this._focusExitListener);
+                this.ariaHostEl.removeEventListener('focus', this._focusExitListener);
             }
         }
     }, {
@@ -344,9 +357,9 @@ module.exports = function () {
         key: 'focus',
         set: function set(bool) {
             if (bool === true) {
-                this.hostEl.addEventListener('focus', this._hostFocusListener);
+                this.ariaHostEl.addEventListener('focus', this._hostFocusListener);
             } else {
-                this.hostEl.removeEventListener('focus', this._hostFocusListener);
+                this.ariaHostEl.removeEventListener('focus', this._hostFocusListener);
             }
         }
     }, {


### PR DESCRIPTION
Because the current expander works only on the host (in this case a button) the aria must be on the element that is "clicked". This changes that behavior allowing a developer to set the aria on a completely different element than the host. This decoupling allows for additionally styling, specifically for the [listbox](https://github.com/eBay/skin/issues/38) use case.