### PR TITLE
fixing document click event for iOS safari

### DIFF
--- a/docs/static/bundle.js
+++ b/docs/static/bundle.js
@@ -873,11 +873,11 @@ function _onDocumentClick(e) {
     processDocumentClick(e, this.el);
 }
 
-function _onDocumentTouchStart(e) {
+function _onDocumentTouchStart() {
     this.documentClick = true;
 }
 
-function _onDocumentTouchMove(e) {
+function _onDocumentTouchMove() {
     this.documentClick = false;
 }
 

--- a/docs/static/bundle.js
+++ b/docs/static/bundle.js
@@ -591,7 +591,7 @@ https://github.com/joyent/node/blob/master/lib/module.js
     }
 })();
 
-$_mod.installed("makeup-expander$0.4.0", "custom-event-polyfill", "0.3.0");
+$_mod.installed("makeup-expander$0.5.0", "custom-event-polyfill", "0.3.0");
 $_mod.main("/custom-event-polyfill$0.3.0", "custom-event-polyfill");
 $_mod.def("/custom-event-polyfill$0.3.0/custom-event-polyfill", function(require, exports, module, __filename, __dirname) { // Polyfill for creating CustomEvents on IE9/10/11
 
@@ -640,7 +640,7 @@ try {
 
 });
 $_mod.run("/custom-event-polyfill$0.3.0/custom-event-polyfill");
-$_mod.installed("makeup-expander$0.4.0", "makeup-next-id", "0.0.2");
+$_mod.installed("makeup-expander$0.5.0", "makeup-next-id", "0.0.2");
 $_mod.main("/makeup-next-id$0.0.2", "");
 $_mod.def("/makeup-next-id$0.0.2/index", function(require, exports, module, __filename, __dirname) { 'use strict';
 
@@ -662,7 +662,7 @@ module.exports = function (el) {
 };
 
 });
-$_mod.installed("makeup-expander$0.4.0", "makeup-exit-emitter", "0.0.4");
+$_mod.installed("makeup-expander$0.5.0", "makeup-exit-emitter", "0.0.4");
 $_mod.main("/makeup-exit-emitter$0.0.4", "");
 $_mod.installed("makeup-exit-emitter$0.0.4", "custom-event-polyfill", "0.3.0");
 $_mod.installed("makeup-exit-emitter$0.0.4", "makeup-next-id", "0.0.1");
@@ -790,7 +790,7 @@ module.exports = {
 };
 
 });
-$_mod.installed("makeup-expander$0.4.0", "makeup-focusables", "0.0.3");
+$_mod.installed("makeup-expander$0.5.0", "makeup-focusables", "0.0.3");
 $_mod.main("/makeup-focusables$0.0.3", "");
 $_mod.def("/makeup-focusables$0.0.3/index", function(require, exports, module, __filename, __dirname) { 'use strict';
 
@@ -818,7 +818,7 @@ module.exports = function (el) {
 };
 
 });
-$_mod.def("/makeup-expander$0.4.0/index", function(require, exports, module, __filename, __dirname) { 'use strict';
+$_mod.def("/makeup-expander$0.5.0/index", function(require, exports, module, __filename, __dirname) { 'use strict';
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
@@ -861,11 +861,30 @@ function _onKeyDown(e) {
     }
 }
 
-function _onDocumentClick(e) {
-    if (this.el.contains(e.target) === false) {
-        this.el.dispatchEvent(new CustomEvent('clickOut', {
+function processDocumentClick(event, el) {
+    if (el.contains(event.target) === false) {
+        el.dispatchEvent(new CustomEvent('clickOut', {
             bubbles: false
         }));
+    }
+}
+
+function _onDocumentClick(e) {
+    processDocumentClick(e, this.el);
+}
+
+function _onDocumentTouchStart(e) {
+    this.documentClick = true;
+}
+
+function _onDocumentTouchMove(e) {
+    this.documentClick = false;
+}
+
+function _onDocumentTouchEnd(e) {
+    if (this.documentClick) {
+        this.documentClick = false;
+        processDocumentClick(e, this.el);
     }
 }
 
@@ -881,6 +900,7 @@ module.exports = function () {
         this.hostContainerEl = null;
         this.hostContainerExpandedClass = this.options.hostContainerClass + '--expanded';
         this.hostIsNested = false;
+        this.documentClick = false;
 
         // ensure the widget and expandee have an id
         nextID(this.el, 'expander');
@@ -890,6 +910,9 @@ module.exports = function () {
 
         this._hostKeyDownListener = _onKeyDown.bind(this);
         this._documentClickListener = _onDocumentClick.bind(this);
+        this._documentTouchStartListener = _onDocumentTouchStart.bind(this);
+        this._documentTouchMoveListener = _onDocumentTouchMove.bind(this);
+        this._documentTouchEndListener = _onDocumentTouchEnd.bind(this);
 
         this._hostClickListener = this.toggle.bind(this);
         this._hostFocusListener = this.expand.bind(this);
@@ -1029,10 +1052,16 @@ module.exports = function () {
         set: function set(bool) {
             if (bool === true) {
                 document.addEventListener('click', this._documentClickListener);
+                document.addEventListener('touchstart', this._documentTouchStartListener);
+                document.addEventListener('touchmove', this._documentTouchMoveListener);
+                document.addEventListener('touchend', this._documentTouchEndListener);
                 this.el.addEventListener('clickOut', this._clickOutListener);
             } else {
                 this.el.removeEventListener('clickOut', this._clickOutListener);
                 document.removeEventListener('click', this._documentClickListener);
+                document.removeEventListener('touchstart', this._documentTouchStartListener);
+                document.removeEventListener('touchmove', this._documentTouchMoveListener);
+                document.removeEventListener('touchend', this._documentTouchEndListener);
             }
         }
     }, {
@@ -1059,7 +1088,7 @@ module.exports = function () {
 }();
 
 });
-$_mod.def("/makeup-expander$0.4.0/docs/index", function(require, exports, module, __filename, __dirname) { function nodeListToArray(nodeList) {
+$_mod.def("/makeup-expander$0.5.0/docs/index", function(require, exports, module, __filename, __dirname) { function nodeListToArray(nodeList) {
     return Array.prototype.slice.call(nodeList);
 }
 
@@ -1067,7 +1096,7 @@ function querySelectorAllToArray(selector) {
     return nodeListToArray(document.querySelectorAll(selector));
 }
 
-var Expander = require('/makeup-expander$0.4.0/index'/*'../index.js'*/);
+var Expander = require('/makeup-expander$0.5.0/index'/*'../index.js'*/);
 var clickExpanderEls = querySelectorAllToArray('.expander--click-only');
 var focusExpanderEls = querySelectorAllToArray('.expander--focus-only');
 var hoverExpanderEls = querySelectorAllToArray('.expander--hover-only');
@@ -1109,4 +1138,4 @@ expanderWidgets.forEach(function(item, i) {
 });
 
 });
-$_mod.run("/makeup-expander$0.4.0/docs/index");
+$_mod.run("/makeup-expander$0.5.0/docs/index");

--- a/index.js
+++ b/index.js
@@ -53,11 +53,11 @@ function _onDocumentClick(e) {
     processDocumentClick(e, this.el);
 }
 
-function _onDocumentTouchStart(e) {
+function _onDocumentTouchStart() {
     this.documentClick = true;
 }
 
-function _onDocumentTouchMove(e) {
+function _onDocumentTouchMove() {
     this.documentClick = false;
 }
 

--- a/index.js
+++ b/index.js
@@ -41,11 +41,30 @@ function _onKeyDown(e) {
     }
 }
 
-function _onDocumentClick(e) {
-    if (this.el.contains(e.target) === false) {
-        this.el.dispatchEvent(new CustomEvent('clickOut', {
+function processDocumentClick(event, el) {
+    if (el.contains(event.target) === false) {
+        el.dispatchEvent(new CustomEvent('clickOut', {
             bubbles: false
         }));
+    }
+}
+
+function _onDocumentClick(e) {
+    processDocumentClick(e, this.el);
+}
+
+function _onDocumentTouchStart(e) {
+    this.documentClick = true;
+}
+
+function _onDocumentTouchMove(e) {
+    this.documentClick = false;
+}
+
+function _onDocumentTouchEnd(e) {
+    if (this.documentClick) {
+        this.documentClick = false;
+        processDocumentClick(e, this.el);
     }
 }
 
@@ -61,6 +80,7 @@ module.exports = function () {
         this.hostContainerEl = null;
         this.hostContainerExpandedClass = this.options.hostContainerClass + '--expanded';
         this.hostIsNested = false;
+        this.documentClick = false;
 
         // ensure the widget and expandee have an id
         nextID(this.el, 'expander');
@@ -70,6 +90,9 @@ module.exports = function () {
 
         this._hostKeyDownListener = _onKeyDown.bind(this);
         this._documentClickListener = _onDocumentClick.bind(this);
+        this._documentTouchStartListener = _onDocumentTouchStart.bind(this);
+        this._documentTouchMoveListener = _onDocumentTouchMove.bind(this);
+        this._documentTouchEndListener = _onDocumentTouchEnd.bind(this);
 
         this._hostClickListener = this.toggle.bind(this);
         this._hostFocusListener = this.expand.bind(this);
@@ -209,10 +232,16 @@ module.exports = function () {
         set: function set(bool) {
             if (bool === true) {
                 document.addEventListener('click', this._documentClickListener);
+                document.addEventListener('touchstart', this._documentTouchStartListener);
+                document.addEventListener('touchmove', this._documentTouchMoveListener);
+                document.addEventListener('touchend', this._documentTouchEndListener);
                 this.el.addEventListener('clickOut', this._clickOutListener);
             } else {
                 this.el.removeEventListener('clickOut', this._clickOutListener);
                 document.removeEventListener('click', this._documentClickListener);
+                document.removeEventListener('touchstart', this._documentTouchStartListener);
+                document.removeEventListener('touchmove', this._documentTouchMoveListener);
+                document.removeEventListener('touchend', this._documentTouchEndListener);
             }
         }
     }, {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "makeup-expander",
   "description": "Creates the basic interactivity for an element that expands and collapses another element.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "index.js",
   "repository": "https://github.com/makeup-js/makeup-expander.git",
   "author": "Ian McBurnie <ianmcburnie@hotmail.com>",

--- a/src/index.js
+++ b/src/index.js
@@ -35,11 +35,30 @@ function _onKeyDown(e) {
     }
 }
 
-function _onDocumentClick(e) {
-    if (this.el.contains(e.target) === false) {
-        this.el.dispatchEvent(new CustomEvent('clickOut', {
+function processDocumentClick(event, el) {
+    if (el.contains(event.target) === false) {
+        el.dispatchEvent(new CustomEvent('clickOut', {
             bubbles: false
         }));
+    }
+}
+
+function _onDocumentClick(e) {
+    processDocumentClick(e, this.el);
+}
+
+function _onDocumentTouchStart() {
+    this.documentClick = true;
+}
+
+function _onDocumentTouchMove() {
+    this.documentClick = false;
+}
+
+function _onDocumentTouchEnd(e) {
+    if (this.documentClick) {
+        this.documentClick = false;
+        processDocumentClick(e, this.el);
     }
 }
 
@@ -53,6 +72,7 @@ module.exports = class {
         this.hostContainerEl = null;
         this.hostContainerExpandedClass = `${this.options.hostContainerClass}--expanded`;
         this.hostIsNested = false;
+        this.documentClick = false;
 
         // ensure the widget and expandee have an id
         nextID(this.el, 'expander');
@@ -62,6 +82,9 @@ module.exports = class {
 
         this._hostKeyDownListener = _onKeyDown.bind(this);
         this._documentClickListener = _onDocumentClick.bind(this);
+        this._documentTouchStartListener = _onDocumentTouchStart.bind(this);
+        this._documentTouchMoveListener = _onDocumentTouchMove.bind(this);
+        this._documentTouchEndListener = _onDocumentTouchEnd.bind(this);
 
         this._hostClickListener = this.toggle.bind(this);
         this._hostFocusListener = this.expand.bind(this);
@@ -142,10 +165,16 @@ module.exports = class {
     set collapseOnClickOut(bool) {
         if (bool === true) {
             document.addEventListener('click', this._documentClickListener);
+            document.addEventListener('touchstart', this._documentTouchStartListener);
+            document.addEventListener('touchmove', this._documentTouchMoveListener);
+            document.addEventListener('touchend', this._documentTouchEndListener);
             this.el.addEventListener('clickOut', this._clickOutListener);
         } else {
             this.el.removeEventListener('clickOut', this._clickOutListener);
             document.removeEventListener('click', this._documentClickListener);
+            document.removeEventListener('touchstart', this._documentTouchStartListener);
+            document.removeEventListener('touchmove', this._documentTouchMoveListener);
+            document.removeEventListener('touchend', this._documentTouchEndListener);
         }
     }
 

--- a/test/data.js
+++ b/test/data.js
@@ -15,7 +15,9 @@ module.exports = [
         },
         expandedState: {
             click: { expandedCount: 0, collapsedCount: 1, ariaExpanded: 'false' },
-            focus: { expandedCount: 0, collapsedCount: 0, ariaExpanded: 'true' }
+            focus: { expandedCount: 0, collapsedCount: 0, ariaExpanded: 'true' },
+            documentClick: { expandedCount: 0, collapsedCount: 0, ariaExpanded: 'true' },
+            documentTouch: { expandedCount: 0, collapsedCount: 0, ariaExpanded: 'true' }
         }
     },
     {
@@ -27,7 +29,23 @@ module.exports = [
         },
         expandedState: {
             click: { expandedCount: 0, collapsedCount: 0, ariaExpanded: 'true' },
-            focus: { expandedCount: 0, collapsedCount: 0, ariaExpanded: 'true' }
+            focus: { expandedCount: 0, collapsedCount: 0, ariaExpanded: 'true' },
+            documentClick: { expandedCount: 0, collapsedCount: 0, ariaExpanded: 'true' },
+            documentTouch: { expandedCount: 0, collapsedCount: 0, ariaExpanded: 'true' }
+        }
+    },
+    {
+        options: { expandOnClick: false, expandOnFocus: true, expandOnHover: false, collapseOnClickOut: true },
+        html: htmlTemplate1,
+        collapsedState: {
+            click: { expandedCount: 0, collapsedCount: 0, ariaExpanded: 'false' },
+            focus: { expandedCount: 1, collapsedCount: 0, ariaExpanded: 'true' }
+        },
+        expandedState: {
+            click: { expandedCount: 0, collapsedCount: 0, ariaExpanded: 'true' },
+            focus: { expandedCount: 0, collapsedCount: 0, ariaExpanded: 'true' },
+            documentClick: { expandedCount: 0, collapsedCount: 1, ariaExpanded: 'false' },
+            documentTouch: { expandedCount: 0, collapsedCount: 1, ariaExpanded: 'false' }
         }
     }
 ];

--- a/test/index.js
+++ b/test/index.js
@@ -1,93 +1,130 @@
 var Expander = require('../index.js');
 var testData = require('./data.js');
 
-testData.forEach(function(data) {
-    var widgetEl;
-    var hostEl;
-    var widget; // eslint-disable-line no-unused-vars
-    var onCollapse;
-    var onExpand;
+testData.forEach(function(data, index) {
+    describe('For test data ' + index, function() {
+        var widgetEl;
+        var hostEl;
+        var widget; // eslint-disable-line no-unused-vars
+        var onCollapse;
+        var onExpand;
 
-    beforeAll(function() {
-        document.body.innerHTML = data.html;
-        widgetEl = document.querySelector('.expander');
-        hostEl = widgetEl.querySelector('.expander__host');
-        onCollapse = jasmine.createSpy('onCollapse');
-        onExpand = jasmine.createSpy('onExpand');
-
-        widgetEl.addEventListener('expander-expand', onExpand);
-        widgetEl.addEventListener('expander-collapse', onCollapse);
-
-        widget = new Expander(widgetEl, data.options);
-    });
-    describe('given the widget is collapsed,', function() {
-        describe('when the host is clicked', function() {
-            beforeAll(function() {
-                hostEl.click();
-            });
-            it('it should observe the correct number of expand events', function() {
-                expect(onExpand).toHaveBeenCalledTimes(data.collapsedState.click.expandedCount);
-            });
-            it('it should observe the correct number of collapse events', function() {
-                expect(onCollapse).toHaveBeenCalledTimes(data.collapsedState.click.collapsedCount);
-            });
-            it('the host el should have correct aria-expanded attribute', function() {
-                expect(hostEl.getAttribute('aria-expanded')).toEqual(data.collapsedState.click.ariaExpanded);
-            });
-        });
-        describe('when the host is focussed', function() {
-            beforeAll(function() {
-                widget.collapse();
-                onExpand.calls.reset();
-                onCollapse.calls.reset();
-                hostEl.focus();
-            });
-            it('it should observe the correct number of expand events', function() {
-                expect(onExpand).toHaveBeenCalledTimes(data.collapsedState.focus.expandedCount);
-            });
-            it('it should observe the correct number of collapse events', function() {
-                expect(onCollapse).toHaveBeenCalledTimes(data.collapsedState.focus.collapsedCount);
-            });
-            it('the host el should have correct aria-expanded attribute', function() {
-                expect(hostEl.getAttribute('aria-expanded')).toEqual(data.collapsedState.focus.ariaExpanded);
-            });
-        });
-    });
-    describe('given the widget is expanded,', function() {
         beforeAll(function() {
-            widget.expand();
-            onExpand.calls.reset();
-            onCollapse.calls.reset();
+            document.body.innerHTML = data.html;
+            widgetEl = document.querySelector('.expander');
+            hostEl = widgetEl.querySelector('.expander__host');
+            onCollapse = jasmine.createSpy('onCollapse');
+            onExpand = jasmine.createSpy('onExpand');
+
+            widgetEl.addEventListener('expander-expand', onExpand);
+            widgetEl.addEventListener('expander-collapse', onCollapse);
+
+            widget = new Expander(widgetEl, data.options);
         });
-        describe('when the host is clicked', function() {
-            beforeAll(function() {
-                hostEl.click();
+        describe('given the widget is collapsed,', function() {
+            describe('when the host is clicked', function() {
+                beforeAll(function() {
+                    hostEl.click();
+                });
+                it('it should observe the correct number of expand events', function() {
+                    expect(onExpand).toHaveBeenCalledTimes(data.collapsedState.click.expandedCount);
+                });
+                it('it should observe the correct number of collapse events', function() {
+                    expect(onCollapse).toHaveBeenCalledTimes(data.collapsedState.click.collapsedCount);
+                });
+                it('the host el should have correct aria-expanded attribute', function() {
+                    expect(hostEl.getAttribute('aria-expanded')).toEqual(data.collapsedState.click.ariaExpanded);
+                });
             });
-            it('it should observe the correct number of expand events', function() {
-                expect(onExpand).toHaveBeenCalledTimes(data.expandedState.click.expandedCount);
-            });
-            it('it should observe the correct number of collapse events', function() {
-                expect(onCollapse).toHaveBeenCalledTimes(data.expandedState.click.collapsedCount);
-            });
-            it('the host el should have correct aria-expanded attribute', function() {
-                expect(hostEl.getAttribute('aria-expanded')).toEqual(data.expandedState.click.ariaExpanded);
+            describe('when the host is focussed', function() {
+                beforeAll(function() {
+                    widget.collapse();
+                    onExpand.calls.reset();
+                    onCollapse.calls.reset();
+                    hostEl.focus();
+                });
+                it('it should observe the correct number of expand events', function() {
+                    expect(onExpand).toHaveBeenCalledTimes(data.collapsedState.focus.expandedCount);
+                });
+                it('it should observe the correct number of collapse events', function() {
+                    expect(onCollapse).toHaveBeenCalledTimes(data.collapsedState.focus.collapsedCount);
+                });
+                it('the host el should have correct aria-expanded attribute', function() {
+                    expect(hostEl.getAttribute('aria-expanded')).toEqual(data.collapsedState.focus.ariaExpanded);
+                });
             });
         });
-        describe('when the host is focussed', function() {
+        describe('given the widget is expanded,', function() {
             beforeAll(function() {
                 widget.expand();
                 onExpand.calls.reset();
                 onCollapse.calls.reset();
-                hostEl.focus();
             });
-            it('it should observe the correct number of expand events', function() {
-                expect(onExpand).toHaveBeenCalledTimes(data.expandedState.focus.expandedCount);
+            describe('when the host is clicked', function() {
+                beforeAll(function() {
+                    hostEl.click();
+                });
+                it('it should observe the correct number of expand events', function() {
+                    expect(onExpand).toHaveBeenCalledTimes(data.expandedState.click.expandedCount);
+                });
+                it('it should observe the correct number of collapse events', function() {
+                    expect(onCollapse).toHaveBeenCalledTimes(data.expandedState.click.collapsedCount);
+                });
+                it('the host el should have correct aria-expanded attribute', function() {
+                    expect(hostEl.getAttribute('aria-expanded')).toEqual(data.expandedState.click.ariaExpanded);
+                });
             });
-            it('it should observe the correct number of collapse events', function() {
-                expect(onCollapse).toHaveBeenCalledTimes(data.expandedState.focus.collapsedCount);
+            describe('when the host is focussed', function() {
+                beforeAll(function() {
+                    widget.expand();
+                    onExpand.calls.reset();
+                    onCollapse.calls.reset();
+                    hostEl.focus();
+                });
+                it('it should observe the correct number of expand events', function() {
+                    expect(onExpand).toHaveBeenCalledTimes(data.expandedState.focus.expandedCount);
+                });
+                it('it should observe the correct number of collapse events', function() {
+                    expect(onCollapse).toHaveBeenCalledTimes(data.expandedState.focus.collapsedCount);
+                });
+                it('the host el should have correct aria-expanded attribute', function() {
+                    expect(hostEl.getAttribute('aria-expanded')).toEqual(data.expandedState.focus.ariaExpanded);
+                });
             });
-            it('the host el should have correct aria-expanded attribute', function() {
-                expect(hostEl.getAttribute('aria-expanded')).toEqual(data.expandedState.focus.ariaExpanded);
+            describe('when the document is clicked', function() {
+                beforeAll(function() {
+                    widget.expand();
+                    onExpand.calls.reset();
+                    onCollapse.calls.reset();
+                    document.body.click();
+                });
+                it('it should observe the correct number of expand events', function() {
+                    expect(onExpand).toHaveBeenCalledTimes(data.expandedState.documentClick.expandedCount);
+                });
+                it('it should observe the correct number of collapse events', function() {
+                    expect(onCollapse).toHaveBeenCalledTimes(data.expandedState.documentClick.collapsedCount);
+                });
+                it('the host el should have correct aria-expanded attribute', function() {
+                    expect(hostEl.getAttribute('aria-expanded')).toEqual(data.expandedState.documentClick.ariaExpanded);
+                });
+            });
+            describe('when the document is touched', function() {
+                beforeAll(function() {
+                    widget.expand();
+                    onExpand.calls.reset();
+                    onCollapse.calls.reset();
+                    document.dispatchEvent(new Event('touchstart'));
+                    document.dispatchEvent(new Event('touchend'));
+                });
+                it('it should observe the correct number of expand events', function() {
+                    expect(onExpand).toHaveBeenCalledTimes(data.expandedState.documentTouch.expandedCount);
+                });
+                it('it should observe the correct number of collapse events', function() {
+                    expect(onCollapse).toHaveBeenCalledTimes(data.expandedState.documentTouch.collapsedCount);
+                });
+                it('the host el should have correct aria-expanded attribute', function() {
+                    expect(hostEl.getAttribute('aria-expanded')).toEqual(data.expandedState.documentTouch.ariaExpanded);
+                });
             });
         });
     });

--- a/test/static/bundle-module.js
+++ b/test/static/bundle-module.js
@@ -267,11 +267,30 @@ function _onKeyDown(e) {
     }
 }
 
-function _onDocumentClick(e) {
-    if (this.el.contains(e.target) === false) {
-        this.el.dispatchEvent(new CustomEvent('clickOut', {
+function processDocumentClick(event, el) {
+    if (el.contains(event.target) === false) {
+        el.dispatchEvent(new CustomEvent('clickOut', {
             bubbles: false
         }));
+    }
+}
+
+function _onDocumentClick(e) {
+    processDocumentClick(e, this.el);
+}
+
+function _onDocumentTouchStart() {
+    this.documentClick = true;
+}
+
+function _onDocumentTouchMove() {
+    this.documentClick = false;
+}
+
+function _onDocumentTouchEnd(e) {
+    if (this.documentClick) {
+        this.documentClick = false;
+        processDocumentClick(e, this.el);
     }
 }
 
@@ -287,6 +306,7 @@ module.exports = function () {
         this.hostContainerEl = null;
         this.hostContainerExpandedClass = this.options.hostContainerClass + '--expanded';
         this.hostIsNested = false;
+        this.documentClick = false;
 
         // ensure the widget and expandee have an id
         nextID(this.el, 'expander');
@@ -296,6 +316,9 @@ module.exports = function () {
 
         this._hostKeyDownListener = _onKeyDown.bind(this);
         this._documentClickListener = _onDocumentClick.bind(this);
+        this._documentTouchStartListener = _onDocumentTouchStart.bind(this);
+        this._documentTouchMoveListener = _onDocumentTouchMove.bind(this);
+        this._documentTouchEndListener = _onDocumentTouchEnd.bind(this);
 
         this._hostClickListener = this.toggle.bind(this);
         this._hostFocusListener = this.expand.bind(this);
@@ -435,10 +458,16 @@ module.exports = function () {
         set: function set(bool) {
             if (bool === true) {
                 document.addEventListener('click', this._documentClickListener);
+                document.addEventListener('touchstart', this._documentTouchStartListener);
+                document.addEventListener('touchmove', this._documentTouchMoveListener);
+                document.addEventListener('touchend', this._documentTouchEndListener);
                 this.el.addEventListener('clickOut', this._clickOutListener);
             } else {
                 this.el.removeEventListener('clickOut', this._clickOutListener);
                 document.removeEventListener('click', this._documentClickListener);
+                document.removeEventListener('touchstart', this._documentTouchStartListener);
+                document.removeEventListener('touchmove', this._documentTouchMoveListener);
+                document.removeEventListener('touchend', this._documentTouchEndListener);
             }
         }
     }, {

--- a/test/static/bundle-module.js
+++ b/test/static/bundle-module.js
@@ -1,4 +1,4 @@
-$_mod.installed("makeup-expander$0.4.0", "custom-event-polyfill", "0.3.0");
+$_mod.installed("makeup-expander$0.5.0", "custom-event-polyfill", "0.3.0");
 $_mod.main("/custom-event-polyfill$0.3.0", "custom-event-polyfill");
 $_mod.def("/custom-event-polyfill$0.3.0/custom-event-polyfill", function(require, exports, module, __filename, __dirname) { // Polyfill for creating CustomEvents on IE9/10/11
 
@@ -46,7 +46,7 @@ try {
 }
 
 });
-$_mod.installed("makeup-expander$0.4.0", "makeup-next-id", "0.0.2");
+$_mod.installed("makeup-expander$0.5.0", "makeup-next-id", "0.0.2");
 $_mod.main("/makeup-next-id$0.0.2", "");
 $_mod.def("/makeup-next-id$0.0.2/index", function(require, exports, module, __filename, __dirname) { 'use strict';
 
@@ -68,7 +68,7 @@ module.exports = function (el) {
 };
 
 });
-$_mod.installed("makeup-expander$0.4.0", "makeup-exit-emitter", "0.0.4");
+$_mod.installed("makeup-expander$0.5.0", "makeup-exit-emitter", "0.0.4");
 $_mod.main("/makeup-exit-emitter$0.0.4", "");
 $_mod.installed("makeup-exit-emitter$0.0.4", "custom-event-polyfill", "0.3.0");
 $_mod.installed("makeup-exit-emitter$0.0.4", "makeup-next-id", "0.0.1");
@@ -196,7 +196,7 @@ module.exports = {
 };
 
 });
-$_mod.installed("makeup-expander$0.4.0", "makeup-focusables", "0.0.3");
+$_mod.installed("makeup-expander$0.5.0", "makeup-focusables", "0.0.3");
 $_mod.main("/makeup-focusables$0.0.3", "");
 $_mod.def("/makeup-focusables$0.0.3/index", function(require, exports, module, __filename, __dirname) { 'use strict';
 
@@ -224,7 +224,7 @@ module.exports = function (el) {
 };
 
 });
-$_mod.def("/makeup-expander$0.4.0/index", function(require, exports, module, __filename, __dirname) { 'use strict';
+$_mod.def("/makeup-expander$0.5.0/index", function(require, exports, module, __filename, __dirname) { 'use strict';
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 


### PR DESCRIPTION
See https://github.com/eBay/ebayui-core/issues/61

Safari on iOS doesn't emit click events on the document.
https://developer.mozilla.org/en-US/docs/Web/Events/click#Safari_Mobile

To fix, I added additional touch events.  There are events for touchstart, touchmove, and touchend so we don't trigger the handler at the beginning of touchmove.

I considered adding device detection so we don't add these events for devices that may trigger both touch and click events, but it doesn't look like duplicate handling will cause a problem. 