### PR TITLE
Adding cancelAsync method;

### DIFF
--- a/docs/static/bundle.js
+++ b/docs/static/bundle.js
@@ -991,6 +991,16 @@ module.exports = function () {
             this.keyDownFlag = false;
         }
     }, {
+        key: 'cancelAsync',
+        value: function cancelAsync() {
+            this.expandOnClick = false;
+            this.expandOnFocus = false;
+            this.expandOnHover = false;
+            this.collapseOnClickOut = false;
+            this.collapseOnFocusOut = false;
+            this.collapseOnMouseOut = false;
+        }
+    }, {
         key: 'expandOnClick',
         set: function set(bool) {
             if (bool === true) {

--- a/index.js
+++ b/index.js
@@ -171,6 +171,16 @@ module.exports = function () {
             this.keyDownFlag = false;
         }
     }, {
+        key: 'cancelAsync',
+        value: function cancelAsync() {
+            this.expandOnClick = false;
+            this.expandOnFocus = false;
+            this.expandOnHover = false;
+            this.collapseOnClickOut = false;
+            this.collapseOnFocusOut = false;
+            this.collapseOnMouseOut = false;
+        }
+    }, {
         key: 'expandOnClick',
         set: function set(bool) {
             if (bool === true) {

--- a/src/index.js
+++ b/src/index.js
@@ -229,4 +229,13 @@ module.exports = class {
         }
         this.keyDownFlag = false;
     }
+
+    cancelAsync() {
+        this.expandOnClick = false;
+        this.expandOnFocus = false;
+        this.expandOnHover = false;
+        this.collapseOnClickOut = false;
+        this.collapseOnFocusOut = false;
+        this.collapseOnMouseOut = false;
+    }
 };

--- a/test/static/bundle-module.js
+++ b/test/static/bundle-module.js
@@ -397,6 +397,16 @@ module.exports = function () {
             this.keyDownFlag = false;
         }
     }, {
+        key: 'cancelAsync',
+        value: function cancelAsync() {
+            this.expandOnClick = false;
+            this.expandOnFocus = false;
+            this.expandOnHover = false;
+            this.collapseOnClickOut = false;
+            this.collapseOnFocusOut = false;
+            this.collapseOnMouseOut = false;
+        }
+    }, {
         key: 'expandOnClick',
         set: function set(bool) {
             if (bool === true) {


### PR DESCRIPTION
This creates a method which allows us to cancel all event listeners. When using a library like Marko we have found a case where the re-rendering of a component fails to cancel the event listeners. Providing this method will let the Marko component cancel those event listeners, and then re-initialize the expander as needed.